### PR TITLE
readme: install -bin package with pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gitlab-ci-verify
 Using pipx you can just use the following command use gitlab-ci-verify as it is:
 
 ```sh
-pipx install gitlab-ci-verify
+pipx install gitlab-ci-verify-bin
 ```
 
 ### Install as library using pip


### PR DESCRIPTION
Otherwise pipx will not see the executable


## Description
```text
❯ pipx --version
1.7.1

❯ pipx install gitlab-ci-verify
Note: Dependent package 'gitlab-ci-verify-bin' contains 1 apps
  - gitlab-ci-verify
Note: Dependent package 'coverage' contains 3 apps
  - coverage
  - coverage-3.13
  - coverage3

No apps associated with package gitlab-ci-verify. Try again with '--include-deps' to include apps of dependent packages, which are listed above. If you are
attempting to install a library, pipx should not be used. Consider using pip or a similar tool instead.

# vs

❯ pipx install gitlab-ci-verify-bin
  installed package gitlab-ci-verify-bin 0.5.4, installed using Python 3.13.1
  These apps are now globally available
    - gitlab-ci-verify
done! ✨ 🌟 ✨
```

The above issue was reproduced on macos `15.1.1` and fedora `41`

