### PR TITLE
fix: [#104] Fix shellcheck location mapping

### DIFF
--- a/internal/gitlab/ci-yaml/virtual_file.go
+++ b/internal/gitlab/ci-yaml/virtual_file.go
@@ -39,7 +39,7 @@ type VirtualCiYamlFile struct {
 // Returns nil if the line is not in the virtual CI YAML
 func (v *VirtualCiYamlFile) Resolve(line int) (*VirtualCiYamlFilePart, *location.Location) {
 	idx := sort.Search(len(v.Parts), func(i int) bool {
-		return v.Parts[i].StartLine > line
+		return v.Parts[i].StartLine >= line
 	})
 	var part *VirtualCiYamlFilePart
 	if idx > 0 {
@@ -111,7 +111,7 @@ func CreateVirtualCiYamlFile(projectRoot string, entryFilePath string, entryFile
 		virtualFile.Parts = append(virtualFile.Parts, part)
 		combined.Write(part.CiYamlFile.FileContent)
 		combined.Write([]byte("\n"))
-		line += part.EndLine + 2
+		line = part.EndLine + 1
 	}
 
 	combined.Write([]byte("\n# Auto generated include block\n"))

--- a/internal/gitlab/ci-yaml/virtual_file_test.go
+++ b/internal/gitlab/ci-yaml/virtual_file_test.go
@@ -138,7 +138,7 @@ func TestGetIgnoredCodes(t *testing.T) {
 								},
 							},
 						},
-						StartLine: 1,
+						StartLine: 0,
 						EndLine:   10,
 					},
 				},

--- a/pkg/checks/shellcheck_scripts_check.go
+++ b/pkg/checks/shellcheck_scripts_check.go
@@ -57,6 +57,11 @@ func (s ShellScriptCheck) Run(i *CheckInput) ([]CheckFinding, error) {
 					}
 
 					loc := i.ResolveLocation(lines[lineNo].Node.Line)
+
+					if loc == nil {
+						panic("Failed to map location for shellcheck finding in line " + strconv.Itoa(lineNo))
+					}
+
 					findingsChan <- CheckFinding{
 						Severity: s.shellcheckLevelToSeverity(f.Level),
 						Code:     fmt.Sprintf("SC-%s", strconv.Itoa(f.Code)),

--- a/pkg/verifier/main.go
+++ b/pkg/verifier/main.go
@@ -145,10 +145,13 @@ func (gcv *GitlabCIVerifier) CreateCheckInput() (*checks.CheckInput, error) {
 			return nil, err
 		}
 
-		mergedCiYaml, err = ci_yaml.NewCiYamlFile([]byte(lintRes.LintResult.MergedYaml))
-		if err != nil {
-			return nil, err
+		if lintRes.LintResult.Valid {
+			mergedCiYaml, err = ci_yaml.NewCiYamlFile([]byte(lintRes.LintResult.MergedYaml))
+			if err != nil {
+				return nil, err
+			}
 		}
+
 	} else {
 		logging.Debug("Skipping lint API check")
 	}


### PR DESCRIPTION
Closes #104

## Description

This should fix the invalid memory address due to nil returned by location resolve. The virtual file offset was incorrect, adjusting it to just the empty line between should fix the stacking offset.

