### PR TITLE
fix: [#105] Fix CI env check

### DIFF
--- a/internal/cli/configuration.go
+++ b/internal/cli/configuration.go
@@ -104,7 +104,8 @@ func (conf *Configuration) Parse() error {
 }
 
 func (conf *Configuration) IsCIEnv() bool {
-	return os.Getenv("CI") != ""
+	_, set := os.LookupEnv("CI")
+	return set
 }
 
 // NewConfiguration creates a new configuration


### PR DESCRIPTION
As of now CI check only checks for a empty string. It should consider everything as CI that actually contains a value.