### PR TITLE
Run pre-commit on changes in included files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   entry: gitlab-ci-verify
   language: golang
   files: .gitlab-ci.*?\.ya?ml$
+  pass_filenames: false


### PR DESCRIPTION
## Description
<!-- Short description about the change, what have you done? -->
 
Hi,

I noticed that the pre-commit only runs if the main .gitlab-ci.yml is changed, but not if an included local config file changes.

I extended the files pattern in the hooks config to run on all changes in files starting with .gitlab-ci and ending in ya?ml (as is the recommended naming per [gitlab docs](https://docs.gitlab.com/ci/yaml/#includelocal).

I also noticed that the filenames are passed to the entrypoint, which is unnecessary as gitlab-ci-verify doesn't take filename args.

So I added pass_filenames=false to avoid this.
 
There was no AI used in writing these changes or PR.
Please let me know if you have objections and I'll be happy to make changes.